### PR TITLE
adding support for --version flag

### DIFF
--- a/src/basecfg/basecfg.py
+++ b/src/basecfg/basecfg.py
@@ -62,6 +62,7 @@ class BaseCfg:
     _prog: Optional[str] = None
     _prog_description: Optional[str] = None
     _prog_epilog: Optional[str] = None
+    _version: Optional[str] = None
 
     def __init__(
         self,
@@ -74,6 +75,7 @@ class BaseCfg:
         prog: Optional[str] = None,
         prog_description: Optional[str] = None,
         prog_epilog: Optional[str] = None,
+        version: Optional[str] = None,
     ) -> None:
         """
         Creates a new instance of the configuration class; all arguments are optional
@@ -92,6 +94,7 @@ class BaseCfg:
         self._prog = prog
         self._prog_description = prog_description
         self._prog_epilog = prog_epilog
+        self._version = version
 
         # step 1: enrich our metadata about the configuration options and load
         # default values. At this point we finally have the names of the fields
@@ -254,6 +257,8 @@ class BaseCfg:
             description=self._prog_description,
             epilog=self._prog_epilog,
         )
+        if self._version:
+            argp.add_argument("--version", action="version", version=self._version)
         for optname, option in self._options.items():
             arg_name = "--" + optname.replace("_", "-")
             option_type = self._base_type(option.option_type)

--- a/tests/testbasecfg/test_source_cli.py
+++ b/tests/testbasecfg/test_source_cli.py
@@ -6,7 +6,7 @@ import pytest
 def test_args_help(config, capsys):
     """test -h support in argparser"""
     with pytest.raises(SystemExit):
-        _ = config(cli_args=["-h"])
+        _ = config(cli_args=["-h"], version="98.76.54")
     captured = capsys.readouterr()
     expected_contents = (
         "--help",
@@ -16,9 +16,31 @@ def test_args_help(config, capsys):
         "--yn",
         "--temps",
         "--favorite-color",
+        "--version",
     )
     for string in expected_contents:
         assert string in captured.out
+
+
+def test_args_version(config, capsys):
+    """verify that setting version on the constructor enables --version functionality"""
+    with pytest.raises(SystemExit):
+        _ = config(cli_args=["--version"], version="98.76.54")
+    captured = capsys.readouterr()
+    expected_content = "98.76.54\n"
+    assert expected_content == captured.out
+
+
+def test_args_version_unset(config, capsys):
+    """
+    verify that --version functionality is unimplemented if version is not set on the
+    constructor
+    """
+    with pytest.raises(SystemExit):
+        _ = config(cli_args=["--version"])
+    captured = capsys.readouterr()
+    expected_content = "error: unrecognized arguments: --version"
+    assert expected_content in captured.err
 
 
 def test_args_full(config):


### PR DESCRIPTION
Adds a `version` argument to the `BaseCfg` constructor; when it is set this implements `--version` support in the CLI argument parser.