### PR TITLE
refactor optfunc/opt; add additional parser param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
 # basecfg
 
-This is a Python class for specifying the configuration that an application can take using type-annotated class attributes. Once a config class is created it populates its config from an optional JSON file (such as a Kubernetes configmap), environment variables, and command-line arguments (all automatically).
+`basecfg` is a Python library designed to simplify and standardize the process of configuring a Python application, particularly a Dockerized application.
+
+Users of this library create a class which inherits from `basecfg.BaseCfg`. For each configuration option an app should support, a type-annotated class attribute is defined using a call to `opt`.
+
+Once a config class is instantiated it automatically populates the configuration from these sources:
+
+1. default values declared in the configuration class
+2. a JSON config file (such as a [Kubernetes ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/))
+3. a `.env` file (in `docker run` envfile format)
+4. environment variables
+5. docker secrets
+6. command-line arguments
+
+## Example
+
+This file is an excerpt from [a more extensive example](docs/example.md) implementation of the library:
+
+```python
+#!/usr/bin/env python3
+from typing import Optional
+
+from basecfg import BaseCfg, opt
+
+
+class ExampleAppConf(BaseCfg):
+    server_username: str = opt(
+        default="demoperson",
+        doc="The username to use on the server",
+    )
+    server_password: Optional[str] = opt(
+        default=None,
+        doc="The password to use on the server",
+        redact=True,
+    )
+    verbose: bool = opt(
+        default=False,
+        doc="whether to log verbosely",
+    )
+    batch_size: Optional[int] = opt(
+        default=None,
+        doc="how many objects to transfer at a time",
+    )
+```

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,0 +1,135 @@
+# basecfg example
+
+The following files show an example implementation of the library. The example is meant to hilight the various ways the app can accept configuration:
+
+1. default values declared in the configuration class
+2. a JSON config file (such as a [Kubernetes ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/))
+3. a `.env` file (in `docker run` format)
+4. environment variables
+5. docker secrets
+6. command-line arguments
+
+
+## src/main.py
+
+```python
+#!/usr/bin/env python3
+from appconf import ExampleAppConf
+
+
+def main():
+    conf = ExampleAppConf(
+        json_config_path="/tmp/configmap.json",
+        prog="exampleapp",
+        version="1.2.3",
+    )
+    print(f'Username: "{conf.server_username}";  password:"{conf.server_password}";')
+    print(f"Verbose?: {conf.verbose!r}; Batch Size: {conf.batch_size!r}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## src/appconf.py
+
+```python
+#!/usr/bin/env python3
+from typing import Optional
+
+from basecfg import BaseCfg, opt
+
+
+class ExampleAppConf(BaseCfg):
+    server_username: str = opt(
+        default="demoperson",
+        doc="The username to use on the server",
+    )
+    server_password: Optional[str] = opt(
+        default=None,
+        doc="The password to use on the server",
+        redact=True,
+    )
+    verbose: bool = opt(
+        default=False,
+        doc="whether to log verbosely",
+    )
+    batch_size: Optional[int] = opt(
+        default=None,
+        doc="how many objects to transfer at a time",
+    )
+```
+
+## Dockerfile
+
+```Dockerfile
+FROM python:3-alpine
+
+COPY src /app/
+ENV PYTHONPATH="/app"
+RUN set -eux; \
+  python3 -m venv /app/venv; \
+  . /app/venv/bin/activate; \
+  pip install basecfg;
+
+ENTRYPOINT [ "/app/venv/bin/python3", "/app/main.py" ]
+```
+
+## configmap.json
+
+```json
+{
+    "batch_size": 42
+}
+```
+
+## docker-compose.yml
+
+```yaml
+services:
+  app:
+    build: .
+    secrets:
+      - server_password
+    environment:
+      SERVER_USERNAME: "demouser3"
+    volumes:
+      - "./configmap.json:/tmp/configmap.json:ro"
+
+secrets:
+  server_password:
+    file: ./.secret-server_password
+```
+
+## Automatic Usage Text
+
+The following text is generated when invoking the container with the `--help` argument.
+
+```
+usage: exampleapp [-h] [--version] [--server-username SERVER_USERNAME]
+                  [--server-password SERVER_PASSWORD]
+                  [--verbose | --no-verbose] [--batch-size BATCH_SIZE]
+
+options:
+  -h, --help            show this help message and exit
+  --version             show program's version number and exit
+  --server-username SERVER_USERNAME
+                        The username to use on the server (default demoperson)
+  --server-password SERVER_PASSWORD
+                        The password to use on the server (default None)
+  --verbose, --no-verbose
+                        whether to log verbosely (default False)
+  --batch-size BATCH_SIZE
+                        how many objects to transfer at a time (default None)
+```
+
+## Invocation
+
+This example invocation shows using command-line arguments.
+
+```shell=/bin/sh
+$ docker compose run --build app --verbose
+Username: "demouser3";  password:"hummus monsieur tiptoeing";
+Verbose?: True; Batch Size: 42
+$
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "basecfg"
-version = "1.2.0"
+version = "2.0.0"
 authors = [
   { name="Ben Burke", email="actualben@users.noreply.github.com" },
 ]

--- a/src/basecfg/__init__.py
+++ b/src/basecfg/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 """ module """
-from .basecfg import BaseCfg
+from .basecfg import BaseCfg, opt
 
-__all__ = ["BaseCfg"]
+__all__ = ["BaseCfg", "opt"]

--- a/tests/testbasecfg/conftest.py
+++ b/tests/testbasecfg/conftest.py
@@ -7,12 +7,9 @@ from typing import List, Optional
 
 import pytest
 
-from basecfg import BaseCfg
-
-opt = BaseCfg.optfunc()
+from basecfg import BaseCfg, opt
 
 
-@opt.link
 class Config(BaseCfg):
     """Configuration for a fictional app"""
 
@@ -46,6 +43,7 @@ class Config(BaseCfg):
         default="blue",
         choices=["blue", "green", "orange"],
         doc="a choice between the best colors",
+        parser=lambda input: str(input).lower(),
     )
 
 

--- a/tests/testbasecfg/test_source_cli.py
+++ b/tests/testbasecfg/test_source_cli.py
@@ -58,7 +58,7 @@ def test_args_full(config):
             "--temps", "212.0",
             "--temps", "98.6",
             "--temps", "32.0",
-            "--favorite-color", "orange",
+            "--favorite-color", "Orange",
             # fmt: on
         ]
     )


### PR DESCRIPTION
* Bumping semver major version (to `2.0.0`) because of the significant breaking change to the API in this PR
* Make `opt` a regular function, remove `optfunc` to implement a new interface (no decorator, directly importing opt)
* implement additional support for the parser parameter (and a basic string case test of it)
* updating documentation

