### PR TITLE
adding logcfg function for writing configuration to a logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "basecfg"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
   { name="Ben Burke", email="actualben@users.noreply.github.com" },
 ]

--- a/tests/testbasecfg/test_access.py
+++ b/tests/testbasecfg/test_access.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """ general access method tests """
+import logging
+
 import pytest
 
 
@@ -50,3 +52,67 @@ def test_contains(config, json_full_good):
     assert conf is not None
     assert ("input_files" in conf) is True
     assert ("output_files" in conf) is False
+
+
+def test_logcfg(config, json_full_good, caplog):
+    """test logging the configuration"""
+    conf = config(json_full_good)
+    assert conf is not None
+
+    logger = logging.getLogger("root")
+    logger.setLevel("DEBUG")
+    conf.logcfg(logger)
+    assert caplog.record_tuples == [
+        ("root", logging.INFO, "running configuration:"),
+        ("root", logging.INFO, "  verbose: True"),
+        ("root", logging.INFO, "  batch_size: 65535"),
+        ("root", logging.INFO, "  input_files: ['a.txt', 'b.txt', 'c.txt']"),
+        ("root", logging.INFO, "  yn: [True, False, True]"),
+        ("root", logging.INFO, "  temps: [1.2, 1.3, 1.4]"),
+        ("root", logging.INFO, "  favorite_color: 'green'"),
+    ]
+
+
+def test_logcfg_redact(config, json_full_good, caplog):
+    """test logging the configuration with a field that has redact=True"""
+    # pylint: disable=protected-access
+    conf = config(json_full_good)
+    conf._options["input_files"] = conf._options["input_files"]._replace(redact=True)
+    assert conf is not None
+
+    logger = logging.getLogger("root")
+    logger.setLevel("DEBUG")
+    conf.logcfg(logger)
+    assert caplog.record_tuples == [
+        ("root", logging.INFO, "running configuration:"),
+        ("root", logging.INFO, "  verbose: True"),
+        ("root", logging.INFO, "  batch_size: 65535"),
+        ("root", logging.INFO, "  input_files: --REDACTED--"),
+        ("root", logging.INFO, "  yn: [True, False, True]"),
+        ("root", logging.INFO, "  temps: [1.2, 1.3, 1.4]"),
+        ("root", logging.INFO, "  favorite_color: 'green'"),
+    ]
+
+
+def test_logcfg_autoredact(config, json_full_good, caplog):
+    """
+    test auto-redaction of field names which contain one of the values in
+    _autoredact_tokens
+    """
+    # pylint: disable=protected-access
+    config._autoredact_tokens = config._autoredact_tokens + ("favorite",)
+    conf = config(json_full_good)
+    assert conf is not None
+
+    logger = logging.getLogger("root")
+    logger.setLevel("DEBUG")
+    conf.logcfg(logger)
+    assert caplog.record_tuples == [
+        ("root", logging.INFO, "running configuration:"),
+        ("root", logging.INFO, "  verbose: True"),
+        ("root", logging.INFO, "  batch_size: 65535"),
+        ("root", logging.INFO, "  input_files: ['a.txt', 'b.txt', 'c.txt']"),
+        ("root", logging.INFO, "  yn: [True, False, True]"),
+        ("root", logging.INFO, "  temps: [1.2, 1.3, 1.4]"),
+        ("root", logging.INFO, "  favorite_color: --AUTO-REDACTED--"),
+    ]


### PR DESCRIPTION
Adds a public method to BaseCfg called `logcfg` for logging configuration information using a given `logging.Logger`